### PR TITLE
Only download glyphs that the site needs.

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <meta property="og:image" content="https://thomasjfox.xyz/media/images/portrait.jpg" />
     <link rel="stylesheet" type="text/css" href="styles/main.css">
     <link rel="icon" href="media/favicon.ico" type="image/x-icon">
-    <link href="https://fonts.googleapis.com/css?family=Anonymous+Pro:400,700" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Anonymous+Pro:400,700&text=012468Thomas%20J.Fx%0A(tl%3Bdr%C3%A9u)He!MyniIwpfgcbC%2CLSDvEUBAk-RjVP'z%2FNQW%3AYG%C2%A9%40" rel="stylesheet">
     <script>
      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),


### PR DESCRIPTION
By requesting only the glyphs present in the visible html from the google fonts API.

Generated:

`cmd+a` On the website.
```
str = `<cmd + v>`
```
```javascript
glyphs = Object.keys([...str].reduce((acc, char) => ({...acc, [char]: true}), {}));
FONT_BASE = "https://fonts.googleapis.com/css?family=Anonymous+Pro:400,700";
font_uri = `${FONT_BASE}&text=${encodeURIComponent(glyphs.join(''))}`
```

TTF, 215 glyphs, 18136 bytes => TTF, 71 glyphs, 7648 bytes per font = 10.5KB savings per font = 21 KB total.

Your site is 60 KB, so this is 1/3rd of the size!!